### PR TITLE
Rewrite wrong Guild entries when reading them.

### DIFF
--- a/integrations/datastore/src/main/java/de/kaiserpfalzedv/rpg/integrations/datastore/cards/MongoCard.java
+++ b/integrations/datastore/src/main/java/de/kaiserpfalzedv/rpg/integrations/datastore/cards/MongoCard.java
@@ -62,7 +62,7 @@ public class MongoCard extends MongoResource<Card> {
     @Override
     public Card data() {
         ImmutableCard.Builder result = ImmutableCard.builder()
-                .metadata(metadata.data());
+                .metadata(metadata.data(id));
 
         if (spec != null) result.spec(spec.data());
 

--- a/integrations/datastore/src/main/java/de/kaiserpfalzedv/rpg/integrations/datastore/guilds/MongoGuild.java
+++ b/integrations/datastore/src/main/java/de/kaiserpfalzedv/rpg/integrations/datastore/guilds/MongoGuild.java
@@ -61,7 +61,7 @@ public class MongoGuild extends MongoResource<Guild> {
     @Override
     public Guild data() {
         ImmutableGuild.Builder result = ImmutableGuild.builder()
-                .metadata(metadata.data());
+                .metadata(metadata.data(id));
 
         if (spec != null) result.spec(spec.data());
         if (status != null) result.status(status.data());

--- a/integrations/datastore/src/main/java/de/kaiserpfalzedv/rpg/integrations/datastore/guilds/MongoGuildStore.java
+++ b/integrations/datastore/src/main/java/de/kaiserpfalzedv/rpg/integrations/datastore/guilds/MongoGuildStore.java
@@ -17,9 +17,13 @@
 
 package de.kaiserpfalzedv.rpg.integrations.datastore.guilds;
 
+import de.kaiserpfalzedv.rpg.core.resources.ImmutableResourceHistory;
+import de.kaiserpfalzedv.rpg.core.resources.ImmutableResourceMetadata;
+import de.kaiserpfalzedv.rpg.core.resources.ImmutableResourceStatus;
 import de.kaiserpfalzedv.rpg.integrations.datastore.resources.MongoResourceStore;
 import de.kaiserpfalzedv.rpg.integrations.discord.guilds.Guild;
 import de.kaiserpfalzedv.rpg.integrations.discord.guilds.GuildStoreService;
+import de.kaiserpfalzedv.rpg.integrations.discord.guilds.ImmutableGuild;
 import io.quarkus.mongodb.panache.PanacheMongoRepository;
 import io.quarkus.mongodb.panache.PanacheQuery;
 import io.quarkus.panache.common.Parameters;
@@ -29,6 +33,10 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
 
 /**
  * MongoGuildRepository -- The persistent datastore for guild configurations.
@@ -65,5 +73,64 @@ public class MongoGuildStore extends MongoResourceStore<Guild, MongoGuild> imple
 
         LOG.trace("query: query='{}', count={}", query, result.count());
         return result;
+    }
+
+
+    @Override
+    public Optional<Guild> findByNameSpaceAndName(final String nameSpace, final String name) {
+        Optional<Guild> result = super.findByNameSpaceAndName(nameSpace, name);
+
+        return repairKind(result);
+    }
+
+    @Override
+    public Optional<Guild> findByUid(final UUID uid) {
+        Optional<Guild> result = super.findByUid(uid);
+
+        return repairKind(result);
+    }
+
+    private Optional<Guild> repairKind(Optional<Guild> input) {
+        if (input.isEmpty() || Guild.KIND.equals(input.get().getKind())) {
+            LOG.trace("Do not rewrite: guild={}", input.orElse(null));
+            return input;
+        }
+
+        LOG.trace("Rewriting: guild={}", input.get());
+
+        long generation = input.get().getGeneration() + 1;
+        Guild output = ImmutableGuild.builder()
+                .from(input.get())
+                .metadata(
+                        ImmutableResourceMetadata.builder()
+                                .from(input.get().getMetadata())
+                                .kind(Guild.KIND)
+                                .generation(generation)
+                                .build()
+                )
+                .status(
+                        ImmutableResourceStatus.builder()
+                                .from(input.get().getStatus().orElse(
+                                        ImmutableResourceStatus.builder()
+                                                .observedGeneration(input.get().getGeneration())
+                                                .build()
+                                ))
+                                .observedGeneration(generation)
+                                .addHistory(
+                                        ImmutableResourceHistory.builder()
+                                                .status("repaired")
+                                                .message("Rewrote kind of this resource from 'User' to 'Guild'.")
+                                                .timeStamp(OffsetDateTime.now(Clock.systemUTC()))
+                                                .build()
+                                )
+                                .build()
+                )
+                .build();
+
+        MongoGuild data = new MongoGuild(output);
+        update(data);
+
+        LOG.debug("Returning rewritten: guild={}", output);
+        return Optional.of(output);
     }
 }

--- a/integrations/datastore/src/main/java/de/kaiserpfalzedv/rpg/integrations/datastore/resources/MongoMetaData.java
+++ b/integrations/datastore/src/main/java/de/kaiserpfalzedv/rpg/integrations/datastore/resources/MongoMetaData.java
@@ -20,6 +20,7 @@ package de.kaiserpfalzedv.rpg.integrations.datastore.resources;
 import de.kaiserpfalzedv.rpg.core.resources.ImmutableResourceMetadata;
 import de.kaiserpfalzedv.rpg.core.resources.ResourceMetadata;
 import org.bson.codecs.pojo.annotations.BsonIgnore;
+import org.bson.types.ObjectId;
 
 import java.beans.Transient;
 import java.util.HashMap;
@@ -65,9 +66,12 @@ public class MongoMetaData extends MongoResourcePointer {
     }
 
 
+    @Override
     @BsonIgnore
     @Transient
-    public ResourceMetadata data() {
+    public ResourceMetadata data(final ObjectId id) {
+        annotations.put("mongo-id", id.toHexString());
+
         ImmutableResourceMetadata.Builder result = ImmutableResourceMetadata.builder()
                 .kind(kind)
                 .apiVersion(apiVersion)

--- a/integrations/datastore/src/main/java/de/kaiserpfalzedv/rpg/integrations/datastore/resources/MongoResource.java
+++ b/integrations/datastore/src/main/java/de/kaiserpfalzedv/rpg/integrations/datastore/resources/MongoResource.java
@@ -21,6 +21,7 @@ import de.kaiserpfalzedv.rpg.core.resources.Resource;
 import io.quarkus.mongodb.panache.MongoEntity;
 import io.quarkus.mongodb.panache.PanacheMongoEntity;
 import org.bson.codecs.pojo.annotations.BsonProperty;
+import org.bson.types.ObjectId;
 
 import java.util.Objects;
 import java.util.StringJoiner;
@@ -55,11 +56,15 @@ public abstract class MongoResource<T extends Resource<?>> extends PanacheMongoE
      * @param data The resource to load data from.
      */
     public void data(final T data) {
+        if (data.getMetadata().isAnnotated("mongo-id")) {
+            id = new ObjectId(data.getMetadata().getAnnotations().get("mongo-id")); // reload the mongodb id from the annotations.
+        }
         uid = data.getUid();
         nameSpace = data.getNameSpace();
         name = data.getName();
 
         metadata = new MongoMetaData(data.getMetadata());
+        metadata.annotations.remove("mongo-id"); // remove the mongodb id if it is in there ...
 
         if (data.getStatus().isPresent()) {
             status = new MongoResourceStatus(data.getStatus().get());

--- a/integrations/datastore/src/main/java/de/kaiserpfalzedv/rpg/integrations/datastore/resources/MongoResourcePointer.java
+++ b/integrations/datastore/src/main/java/de/kaiserpfalzedv/rpg/integrations/datastore/resources/MongoResourcePointer.java
@@ -20,6 +20,7 @@ package de.kaiserpfalzedv.rpg.integrations.datastore.resources;
 import de.kaiserpfalzedv.rpg.core.resources.ImmutableResourcePointer;
 import de.kaiserpfalzedv.rpg.core.resources.ResourcePointer;
 import org.bson.codecs.pojo.annotations.BsonIgnore;
+import org.bson.types.ObjectId;
 
 import java.beans.Transient;
 import java.util.Objects;
@@ -53,6 +54,12 @@ public class MongoResourcePointer {
     @BsonIgnore
     @Transient
     public ResourcePointer data() {
+        return data(null);
+    }
+
+    @BsonIgnore
+    @Transient
+    public ResourcePointer data(final ObjectId id) {
         return ImmutableResourcePointer.builder()
                 .kind(kind)
                 .apiVersion(apiVersion)

--- a/integrations/datastore/src/main/java/de/kaiserpfalzedv/rpg/integrations/datastore/users/MongoUser.java
+++ b/integrations/datastore/src/main/java/de/kaiserpfalzedv/rpg/integrations/datastore/users/MongoUser.java
@@ -59,7 +59,7 @@ public class MongoUser extends MongoResource<User> {
     @Transient
     public User data() {
         ImmutableUser.Builder result = ImmutableUser.builder()
-                .metadata(metadata.data());
+                .metadata(metadata.data(id));
 
         if (spec != null) {
             result.spec(spec.data());

--- a/rpg-core/src/main/java/de/kaiserpfalzedv/rpg/core/dice/history/RollHistory.java
+++ b/rpg-core/src/main/java/de/kaiserpfalzedv/rpg/core/dice/history/RollHistory.java
@@ -25,7 +25,9 @@ import de.kaiserpfalzedv.rpg.core.resources.SerializableList;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 /**
  * RollHistory -- The history of rolls for an user in a session.
@@ -47,6 +49,10 @@ public interface RollHistory extends Resource<SerializableList<RollHistoryEntry>
      */
     @Value.Default
     default List<RollHistoryEntry> getList() {
-        return getSpec().orElseThrow();
+        try {
+            return getSpec().orElseThrow();
+        } catch (NoSuchElementException e) {
+            return new ArrayList<>();
+        }
     }
 }

--- a/rpg-core/src/main/java/de/kaiserpfalzedv/rpg/core/dice/history/RollHistoryEntry.java
+++ b/rpg-core/src/main/java/de/kaiserpfalzedv/rpg/core/dice/history/RollHistoryEntry.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import de.kaiserpfalzedv.rpg.core.dice.mat.RollTotal;
+import de.kaiserpfalzedv.rpg.core.resources.ResourcePointer;
 import de.kaiserpfalzedv.rpg.core.user.User;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.immutables.value.Value;
@@ -45,9 +46,9 @@ import java.time.OffsetDateTime;
 @Schema(name = "RollHistory", description = "A single dice roll.")
 public interface RollHistoryEntry extends Serializable {
     /**
-     * @return the session this roll history belongs to.
+     * @return the game this roll history belongs to.
      */
-    String getSession();
+    ResourcePointer getGame();
 
     /**
      * @return The user who rolled this roll.


### PR DESCRIPTION
**Describe the content of this pull request**
When a mongo entry is read, the mongodb ID is put as annotation on the transfer object. This is needed for on-the-fly rewrite of the buggy Guild objects in the database because I didn't want to do it on the MongoGuild level but on the MongoGuildStore level.

**List the issues solved**
- fixes #90